### PR TITLE
Improve page cycle parsing and output logic

### DIFF
--- a/Amazon.in Scraping All Product Reviews.ipynb
+++ b/Amazon.in Scraping All Product Reviews.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,39 +26,38 @@
     "!{sys.executable} -m pip install bs4\n",
     "!{sys.executable} -m pip install lxml\n",
     "!{sys.executable} -m pip install pandas\n",
+    "!{sys.executable} -m pip install dateparser\n",
+    "import dateparser\n",
     "import time\n",
     "import requests\n",
     "import lxml\n",
     "from bs4 import BeautifulSoup\n",
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Enter the product link: https://www.amazon.de/dp/B07SJR6HL3?ref=dacx_dp_1486540050202_3693756170602&pd_rd_plhdr=t&aaxitk=oKhWNvWHnPkBHCjSwhrxXw\n"
-     ]
-    }
-   ],
-   "source": [
-    "product_link = input('Enter the product link: ')"
+    "import pandas as pd\n",
+    "\n",
+    "def get_page(link):\n",
+    "    headers = {'User-Agent': 'Mozilla/5.0 (X11; U; Linux i686; en-US) AppleWebKit/534.3 (KHTML, like Gecko) Chrome/6.0.472.64 Safari/534.3'}\n",
+    "    page = requests.get(link, headers=headers)\n",
+    "    return BeautifulSoup(page.text, 'lxml')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter the product link: https://www.amazon.in/Test-Exclusive-608/dp/B07HGBMJT6/ref=sr_1_1?keywords=oneplus+7&qid=1563085781&s=gateway&smid=A35FCS7U51TK3C&sr=8-1\n",
+      "https://www.amazon.in\n"
+     ]
+    }
+   ],
    "source": [
-    "headers = {'User-Agent': 'Mozilla/5.0 (X11; U; Linux i686; en-US) AppleWebKit/534.3 (KHTML, like Gecko) Chrome/6.0.472.64 Safari/534.3'}\n",
-    "product_page = requests.get(product_link, headers=headers)\n",
-    "#print(product_page)"
+    "product_link = input('Enter the product link: ')\n",
+    "relative_url_prefix = \"/\".join(product_link.split(\"/\", 3)[:3])\n",
+    "print(relative_url_prefix)"
    ]
   },
   {
@@ -67,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "product_page_soup = BeautifulSoup(product_page.text, 'lxml')\n",
+    "product_page_soup = get_page(product_link)\n",
     "#print(product_page_soup)"
    ]
   },
@@ -80,13 +79,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://www.amazon.de/Soundcore-Ger%C3%A4uschisolierung-kristallklares-Akkulaufzeit-Wasserschutzklasse-Schwarz/product-reviews/B07SJR6HL3/ref=cm_cr_dp_d_show_all_btm?ie=UTF8&reviewerType=all_reviews\n"
+      "https://www.amazon.in/Test-Exclusive-608/product-reviews/B07HGBMJT6/ref=cm_cr_dp_d_show_all_btm?ie=UTF8&reviewerType=all_reviews\n"
      ]
     }
    ],
    "source": [
     "see_all_reviews = product_page_soup.find_all(\"a\", {\"data-hook\" : \"see-all-reviews-link-foot\"})[0]\n",
-    "all_reviews_url =  \"/\".join(product_link.split(\"/\", 3)[:3]) + see_all_reviews['href']\n",
+    "all_reviews_url =  relative_url_prefix + see_all_reviews['href']\n",
     "print(all_reviews_url)"
    ]
   },
@@ -96,70 +95,62 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_reviews_page = requests.get(all_reviews_url, headers=headers)\n",
-    "all_reviews_page_soup = BeautifulSoup(all_reviews_page.text, 'lxml')\n",
+    "review_page_limit = 5\n",
+    "timestr = time.strftime(\"%Y%m%d-%H%M%S\")\n",
+    "csvoutput_file = f'.{os.path.sep}review_{timestr}.csv'\n",
     "\n",
-    "#do\n",
-    "i=1\n",
-    "# review_id = [i['id'] for i in all_reviews_page_soup.find_all(class_='a-section review aok-relative')[2:]]\n",
-    "names = list([i.text for i in all_reviews_page_soup.find_all(class_='a-profile-name')[2:]])\n",
-    "ratings = list([i.find(class_='a-icon-alt').text[:3] for i in all_reviews_page_soup.find_all(class_='a-section celwidget')])\n",
-    "title = list([i.span.text for i in all_reviews_page_soup.find_all(class_='review-title')[2:]])\n",
-    "date = list([i.text for i in all_reviews_page_soup.find_all(class_='review-date')[2:]])\n",
-    "text = list([i.span.text for i in all_reviews_page_soup.find_all(class_='review-text-content')])\n",
-    "#while\n",
-    "# print(type(all_reviews_page_soup.find(class_='a-pagination').find_all('li')[1].a))\n",
+    "all_reviews_page_soup = get_page(all_reviews_url)\n",
+    "\n",
+    "def parse_review_date(review_date_text):\n",
+    "    reduced_date_text = \" \".join(review_date_text.split()[-3:])\n",
+    "    return dateparser.parse(reduced_date_text).isoformat()\n",
+    "\n",
+    "def parse_reviews(soup):\n",
+    "    parsed = []\n",
+    "    for review in soup.find_all(\"div\", {\"data-hook\" : \"review\"}):\n",
+    "        try:\n",
+    "            parsed.append({\n",
+    "                'id': review['id'],\n",
+    "                'name': review.find(\"span\", {\"class\" : \"a-profile-name\"}).text,\n",
+    "                'rating': review.find(class_='a-section celwidget').find(class_='a-icon-alt').text[:3],\n",
+    "                'title': review.find(\"a\", {\"data-hook\" : \"review-title\"}).find(\"span\").text,\n",
+    "                'date': parse_review_date(review.find(\"span\", {\"data-hook\" : \"review-date\"}).text),\n",
+    "                'text': review.find(\"span\", {\"data-hook\": \"review-body\"}).find(\"span\").text.strip()\n",
+    "            })\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "    #print(parsed)\n",
+    "    #print(len(parsed))\n",
+    "    return parsed\n",
+    "\n",
+    "def has_next_page(soup):\n",
+    "    return relative_url_prefix + soup.find(\"li\", { \"class\" : \"a-last\"}).find(\"a\")[\"href\"]\n",
+    "\n",
+    "def append_to_csv(list):\n",
+    "    pd.DataFrame(list).to_csv(csvoutput_file, mode='a', index=False, header=False)\n",
+    "\n",
     "try:\n",
-    "    while all_reviews_page_soup.find(class_='a-pagination'):\n",
-    "        if all_reviews_page_soup.find(class_='a-pagination').find_all('li')[1].a:\n",
-    "            #print(i)\n",
-    "            i+=1\n",
-    "            next_url = 'https://www.amazon.in' + all_reviews_page_soup.find(class_='a-pagination').find_all('li')[1].a['href']\n",
-    "            all_reviews_page = requests.get(next_url)\n",
-    "            all_reviews_page_soup = BeautifulSoup(all_reviews_page.text, 'html.parser')\n",
-    "    #         review_id.append([i['id'] for i in all_reviews_page_soup.find_all(class_='a-section review aok-relative')[2:]])\n",
-    "            temp_names = [i.text for i in all_reviews_page_soup.find_all(class_='a-profile-name')[2:]]\n",
-    "            if temp_names:\n",
-    "                names.append(temp_names)\n",
-    "            else:\n",
-    "                names.append('')\n",
-    "            temp_ratings = [i.find(class_='a-icon-alt').text[:3] for i in all_reviews_page_soup.find_all(class_='a-section celwidget')]\n",
-    "            if temp_ratings:\n",
-    "                ratings.append(temp_ratings)\n",
-    "            else:\n",
-    "                ratings.append('')\n",
-    "            temp_title = [i.span.text for i in all_reviews_page_soup.find_all(class_='review-title')[2:]]\n",
-    "            if temp_title:\n",
-    "                title.append(temp_title)\n",
-    "            else:\n",
-    "                title.append('')\n",
-    "            temp_date = [i.text for i in all_reviews_page_soup.find_all(class_='review-date')[2:]]\n",
-    "            if temp_date:\n",
-    "                date.append(temp_date)\n",
-    "            else:\n",
-    "                date.append('')\n",
-    "            temp_text = [i.span.text for i in all_reviews_page_soup.find_all(class_='review-text-content')]\n",
-    "            if temp_text:\n",
-    "                text.append(temp_text)\n",
-    "            else:\n",
-    "                text.append('')\n",
-    "        else:\n",
+    "    page_counter = 0\n",
+    "    parsed_page = parse_reviews(all_reviews_page_soup)\n",
+    "    append_to_csv(parsed_page)\n",
+    "    \n",
+    "    # get next page\n",
+    "    while True:\n",
+    "        page_counter += 1\n",
+    "        if page_counter >= review_page_limit:\n",
     "            break\n",
+    "\n",
+    "        next_page_link = has_next_page(all_reviews_page_soup)\n",
+    "        #print(next_page_link)\n",
+    "        if not next_page_link:\n",
+    "            break\n",
+    "\n",
+    "        all_reviews_page_soup = get_page(next_page_link)\n",
+    "        parsed_page = parse_reviews(all_reviews_page_soup)\n",
+    "        append_to_csv(parsed_page)\n",
+    "    \n",
     "except Exception as e:\n",
-    "    print(e, type(all_reviews_page_soup.find(class_='a-pagination')))\n",
-    "#print('Name'+str(len(names))+'Ratings'+str(len(ratings))+'Title'+str(len(title))+'Date'+str(len(date))+'Text'+str(len(text)))\n",
-    "reviews_dict = {'Name':names, 'Ratings':ratings, 'Title':title, 'Date':date, 'Text':text}\n",
-    "#print(reviews_dict)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reviews_df = pd.DataFrame.from_dict(reviews_dict)\n",
-    "#print(reviews_df)"
+    "    print(e)\n"
    ]
   },
   {
@@ -171,15 +162,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "timestr = time.strftime(\"%Y%m%d-%H%M%S\")\n",
-    "csvoutput_file = f'.{os.path.sep}review_{timestr}.csv'\n",
-    "#print(f'saving to {csvoutput_file}')\n",
-    "reviews_df.to_csv(csvoutput_file)"
-   ]
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Closes #2 

To fix the csv output I decided to rewrite the parsing part to have a better performance output (chunk appending) and prohibit memory exhaustion.

I also created a setting to limit the calls to paging loop because some products have over 23K reviews (worldwide), which causes the application to run almost infintely.

The fields are now in the desired order - but I had to disable the index column, because the chunking appends a new dataframe after each page call. I also think that the order of the reviews is not very clear when calling them from the site so I hope it is ok to lose that column.
